### PR TITLE
various improvements 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,25 @@ __Brief:__
 
 Use this script to setup a complete local running nightscout instance with a local mongoDB instance
 
+
+__Prerequisites__
+
+1. Make sure your Raspberry kernel is up to date 
+   `$ sudo apt-get install rpi-update && sudo rpi-update `
+   and reboot.
+
+2. Configure your Rasberry Pi
+   `$ sudo raspi-config`
+```   
+1. Expand Filesystem   ==> Make use of the whole SD-CARD
+2. Change User Password     	
+3. Bootoptions ==> Choose what you want
+4. Wait for Network at Boot ==> Set to No
+5.  Internationalisation Options => Change Locale, Timezone, Keyboard Layout, Wi-Fi country to your needs
+A2. Hostname ==> Set your hostname. This will be used for the URL of your Nightscout 
+A4. SSH ==> Enable SSH for remote access
+```
+
 __Usage:__
 
  1. open console on your raspi eg `ssh pi@192.168.10.4` default-password `raspberry` and run ns-local-install script:
@@ -44,10 +63,14 @@ The patches for mongo2.x compatibility are now merged back into the official dev
 
 __With help from:__
 
-https://c-ville.gitbooks.io/test/content/
+- https://c-ville.gitbooks.io/test/content/
+- http://yannickloriot.com/2016/04/install-mongodb-and-node-js-on-a-raspberry-pi/
+- https://www.einplatinencomputer.com/raspberry-pi-node-js-installieren/
+- contributions from PieterGit
 
-http://yannickloriot.com/2016/04/install-mongodb-and-node-js-on-a-raspberry-pi/
-
-https://www.einplatinencomputer.com/raspberry-pi-node-js-installieren/
-
-contributions from PieterGit
+__Whishlist/To Do:__
+- seperate username/password for Mongo
+- Nginx to use for https / letsencrypt certificate
+- Script to create wifi hotspot on the raspberry pi
+- Always install latest Node (now 6.8.0 instead of 6.7.0 what is being installed)
+- ...

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,8 @@
 __Tested with:__
 
-- Raspberry Pi 3: Everything works nicely now
-- Raspberry Pi (1) Model B: Working with Raspian Jessie Lite and with PIXEL (Release date: 2016-09-23)
+- Raspberry Pi 3 (rpi3): Everything works nicely now
+- Raspberry Pi 1 Model B (rpi1): Working with Raspian Jessie Lite with PIXEL (Release date: 2016-09-23)
+- Raspberry Pi Zero (rpi0): Working with Raspian Jessie Lite (Release date: 2016-09-23)
 
 __Brief:__
 
@@ -13,27 +14,33 @@ __Usage:__
     `curl -s https://raw.githubusercontent.com/SandraK82/deploy-ns-local-raspi/master/ns-local-install.sh | bash -`
     relax and drink some :coffee: - script runtime *over 1.5 hour* on clean and fresh raspi.
  2. after running the script you will have a running nightscout local installation. Now open editor with your config for nightscout.
-    `nano /home/pi/cgm-remote-monitor/my.env`
+    `nano /home/pi/cgm-remote-monitor/start-nightscout.sh`
      You need to configure at least the lines at the top of the file:
     `CUSTOM_TITLE=mysitename_without_spaces`
-    `API_SECRET=my_12_character_passwort`
-
+    `API_SECRET=my_12_characters_or_more_password``
+	
     Put your personal password (at least 12 characters long) and the name of your site (just for display) there!
-    Please note that you _CAN_NOT_ have any spaces in your configuration. To separate values use `%20` instead. For the CUSTOM_TITLE Parameter this does not work!
+ 
  3. once finished, restart nightscout with: `sudo /etc/init.d/nightscout stop && sudo /etc/init.d/nightscout start`
  4. navigate to http://192.168.10.4:1337/ complete nightscout profile settings
  5. Have fun :smiley:
 
 __Troubleshooting:__
 
- * nodejs manual start: `pi@raspberrypi:~/cgm-remote-monitor $ env $(cat my.env) PORT=1337 node server.js` (must be in cgm-remote-monitor directory)
+ * nodejs manual start: `pi@raspberrypi:~/cgm-remote-monitor $ start-nightscout.sh` (must be in cgm-remote-monitor directory)
+ * nodejs / nightscout log: check `cat /var/log/openaps/nightscout.log` 
  * mongodb check `cat /var/log/mongodb/mongodb.log` should contain: `[initandlisten] waiting for connections on port 27017`
 
-__Updates:__
+__Changelog:__
 
 ~~I forked the current dev-branch of nightscout/cgm-remote-monitor and changed the mongodb compatibility problems. Now it runs smoothly with mongodb 2.x on a raspi!
 Maybe the pull request gets accepted soon. As soon as I´m notified, I will change the script again to use the current dev-branch again.~~
 The patches for mongo2.x compatibility are now merged back into the official dev branch.
+
+2016-10-14: 
+
+- change to nightscout 0.9.0 stable Grilled Cheese)
+- add start_nightscout.sh instead of my.env
 
 __With help from:__
 
@@ -42,3 +49,5 @@ https://c-ville.gitbooks.io/test/content/
 http://yannickloriot.com/2016/04/install-mongodb-and-node-js-on-a-raspberry-pi/
 
 https://www.einplatinencomputer.com/raspberry-pi-node-js-installieren/
+
+contributions from PieterGit

--- a/install_wifi_hotspot.sh
+++ b/install_wifi_hotspot.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# based on http://elinux.org/RPI-Wireless-Hotspot
+
+sudo apt-get install hostapd udhcpd
+
+# TODO: change the config files
+
+sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
+#sudo service hostapd start
+#sudo service udhcpd start

--- a/nightscout
+++ b/nightscout
@@ -1,5 +1,5 @@
 #!/bin/sh
-# /etc/init.d/node
+# /etc/init.d/nightscout
 
 if [ true != "$INIT_D_SCRIPT_SOURCED" ] ; then
     set "$0" "$@"; INIT_D_SCRIPT_SOURCED=true . /lib/init/init-d-script
@@ -19,8 +19,8 @@ export PATH=$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/
 
 DAEMON_PATH="/home/pi/cgm-remote-monitor"
 
-DAEMON=env
-DAEMONOPTS="$(cat /home/pi/cgm-remote-monitor/my.env) PORT=1337 node server.js"
+DAEMON=/usr/bin/sudo
+DAEMONOPTS="-u pi /home/pi/start_nightscout.sh"
 NAME=nightscout
 DESC="nightscout pi local script"
 PIDFILE=/var/run/$NAME.pid
@@ -30,7 +30,7 @@ case "$1" in
 start)
     printf "%-50s" "Starting $NAME..."
     cd $DAEMON_PATH
-    PID=`$DAEMON $DAEMONOPTS > /var/log/openaps/nightscout.log 2>&1 & echo $!`
+    PID=`$DAEMON $DAEMONOPTS > /var/log/nightscout.log 2>&1 & echo $!`
     #echo "Saving PID" $PID " to " $PIDFILE
     if [ -z $PID ]; then
         printf "%s\n" "Fail"

--- a/nightscout
+++ b/nightscout
@@ -30,7 +30,7 @@ case "$1" in
 start)
     printf "%-50s" "Starting $NAME..."
     cd $DAEMON_PATH
-    PID=`$DAEMON $DAEMONOPTS > /dev/null 2>&1 & echo $!`
+    PID=`$DAEMON $DAEMONOPTS > /var/log/openaps/nightscout.log 2>&1 & echo $!`
     #echo "Saving PID" $PID " to " $PIDFILE
     if [ -z $PID ]; then
         printf "%s\n" "Fail"

--- a/ns-local-install.sh
+++ b/ns-local-install.sh
@@ -31,8 +31,12 @@ else
 fi
 
 
-# prepare npm
-sudo apt-get install -y npm
+# install dependencies 
+# get git, mongodb 2.x from apt for now,and npm
+# optional extra packages to easily debug stuff or to do better maintenance
+EXTRAS="etckeeper tcsh lsof"
+sudo apt-get install --assume-yes git mongodb-server npm $EXTRAS
+
 sudo npm cache clean -f
 sudo npm install npm -g
 sudo npm install n -g
@@ -40,8 +44,6 @@ sudo npm install n -g
 # select matching node
 sudo n 4.6
 
-# install the mongodb 2.x from apt for now
-sudo apt-get install -y mongodb-server
 # enable mongo
 sudo systemctl enable mongodb.service
 # check mongo status
@@ -51,8 +53,11 @@ sudo systemctl status mongodb.service
 
 # go home
 cd
-# get ns
-sudo apt-get install --assume-yes git
+
+# get start script
+curl -o start_nightscout.sh https://raw.githubusercontent.com/PieterGit/deploy-ns-local-raspi/master/start_nightscout.sh
+
+
 git clone https://github.com/nightscout/cgm-remote-monitor.git
 
 # switching to cgm-remote-monitor directory
@@ -63,8 +68,6 @@ git checkout master
 # setup ns
 ./setup.sh
 
-# put your config into it
-curl -o start_nightscout.sh https://raw.githubusercontent.com/PieterGit/deploy-ns-local-raspi/master/start_nightscout.sh
 
 # make autoboot
 cd

--- a/ns-local-install.sh
+++ b/ns-local-install.sh
@@ -2,6 +2,8 @@
 
 ## from https://raw.githubusercontent.com/SandraK82/deploy-ns-local-raspi/master/ns-local-install.sh
 
+## TODO: set /etc/domainname
+
 # make me current
 sudo apt-get update && sudo apt-get upgrade -y
 
@@ -55,18 +57,18 @@ git clone https://github.com/nightscout/cgm-remote-monitor.git
 
 # switching to cgm-remote-monitor directory
 cd cgm-remote-monitor/
-# switch to dev
-git checkout dev
+# switch to master (latest stable version)
+git checkout master
 
 # setup ns
 ./setup.sh
 
 # put your config into it
-curl -o my.env https://raw.githubusercontent.com/SandraK82/deploy-ns-local-raspi/master/my.env
+curl -o start_nightscout.sh https://raw.githubusercontent.com/PieterGit/deploy-ns-local-raspi/master/start_nightscout.sh
 
 # make autoboot
 cd
-curl -o nightscout https://raw.githubusercontent.com/SandraK82/deploy-ns-local-raspi/master/nightscout
+curl -o nightscout https://raw.githubusercontent.com/PieterGit/deploy-ns-local-raspi/master/nightscout
 sudo mv nightscout /etc/init.d/nightscout
 sudo chmod +x /etc/init.d/nightscout
 sudo /etc/init.d/nightscout start
@@ -74,4 +76,15 @@ sudo /etc/init.d/nightscout status
 sudo insserv -d nightscout
 
 echo "deploy nightscout on raspi done :)"
-echo "Dont forget to edit: /home/pi/cgm-remote-monitor/my.env"
+echo "Dont forget to edit: /home/pi/cgm-remote-monitor/start_nightscout.sh"
+echo "Nightscout logging can be found at: /var/log/openaps/nightscout.log"
+
+# Setup basis oref0 stuff
+# https://openaps.readthedocs.io/en/dev/docs/walkthrough/phase-2/oref0-setup.html
+curl -s https://raw.githubusercontent.com/openaps/docs/master/scripts/quick-packages.sh | bash -
+
+mkdir -p ~/src; cd ~/src && git clone -b dev git://github.com/openaps/oref0.git || (cd oref0 && git checkout dev && git pull)
+
+
+echo "Please continue with step 2 of https://openaps.readthedocs.io/en/dev/docs/walkthrough/phase-2/oref0-setup.html"
+echo "cd && ~/src/oref0/bin/oref0-setup.sh"

--- a/ns-local-install.sh
+++ b/ns-local-install.sh
@@ -56,7 +56,7 @@ cd
 
 # get start script
 curl -o start_nightscout.sh https://raw.githubusercontent.com/PieterGit/deploy-ns-local-raspi/master/start_nightscout.sh
-
+chmod +rx start_nightscout.sh
 
 git clone https://github.com/nightscout/cgm-remote-monitor.git
 

--- a/start_nightscout.sh
+++ b/start_nightscout.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+cd /home/pi/cgm-remote-monitor
+
+# See https://github.com/nightscout/cgm-remote-monitor#environment for a description of the fields
+# Required by Nightscout, please edit
+export CUSTOM_TITLE=mysitename_without_spaces
+export API_SECRET=my_12_characters_or_more_password
+
+# 
+# Required by Nightscout
+# Used for building links to your sites api, ie pushover callbacks, usually the URL of your Nightscout site 
+# TODO: get the FQDN here
+BASE_URL="http://`hostname`:1337/
+
+# Required by Nightscout
+# Your mongo uri, for example: mongodb://sally:sallypass@ds099999.mongolab.com:99999/nightscout
+# TODO: secure mongo collection with generated username / password
+export MONGO_CONNECTION=mongodb://localhost:27017/nightscout
+
+# DISPLAY_UNITS. Choices: mg/dl and mmol. Setting to mmol puts the entire server into mmol mode by default, no further settings needed
+export DISPLAY_UNITS=mmol
+#export DISPLAY_UNITS=mg/dl
+
+export ENABLE="delta direction timeago devicestatus ar2 profile careportal boluscalc food rawbg iob cob bwp cage sage iage treatmentnotify basal pump openaps"
+export DISABLE="upbat errorcodes simplealarms bridge mmconnect loop"
+
+export TIME_FORMAT=24
+export NIGHT_MODE=off
+export SHOW_RAWBG=always
+
+export THEME=colors
+
+export ALARM_TIMEAGO_WARN=on
+export ALARM_TIMEAGO_WARN_MINS=15
+export ALARM_TIMEAGO_URGENT=on
+export ALARM_TIMEAGO_URGENT_MINS=30
+
+export PROFILE_HISTORY=off
+export PROFILE_MULTIPLE=off
+
+export BWP_WARN=0.50
+export BWP_URGENT=1.00
+export BWP_SNOOZE_MINS=10
+export BWP_SNOOZE=0.10
+
+export CAGE_ENABLE_ALERTS=true
+export export CAGE_INFO=44
+export CAGE_WARN=48
+export CAGE_URGENT=72
+export CAGE_DISPLAY=hours
+
+export SAGE_ENABLE_ALERTS=false
+export SAGE_INFO=144
+export SAGE_WARN=164
+export SAGE_URGENT=166
+
+export IAGE_ENABLE_ALERTS=false
+export IAGE_INFO=44
+export IAGE_WARN=48
+export IAGE_URGENT=72
+
+export TREATMENTNOTIFY_SNOOZE_MINS=10
+
+export BASAL_RENDER=default
+
+export BRIDGE_USER_NAME=
+export BRIDGE_PASSWORD=
+export BRIDGE_INTERVAL=150000
+export BRIDGE_MAX_COUNT=1
+export BRIDGE_FIRST_FETCH_COUNT=3
+export BRIDGE_MAX_FAILURES=3
+export BRIDGE_MINUTES=1400
+
+export MMCONNECT_USER_NAME=
+export MMCONNECT_PASSWORD=
+export MMCONNECT_INTERVAL=60000
+export MMCONNECT_MAX_RETRY_DURATION=32
+export MMCONNECT_SGV_LIMIT=24
+export MMCONNECT_VERBOSE=false
+export MMCONNECT_STORE_RAW_DATA=false
+
+export DEVICESTATUS_ADVANCED="true"
+
+export PUMP_ENABLE_ALERTS=true
+export PUMP_FIELDS="reservoir battery clock status"
+export PUMP_RETRO_FIELDS="reservoir battery clock"
+export PUMP_WARN_CLOCK=30
+export PUMP_URGENT_CLOCK=60
+export PUMP_WARN_RES=50
+export PUMP_URGENT_RES=10
+export PUMP_WARN_BATT_P=30
+export PUMP_URGENT_BATT_P=20
+export PUMP_WARN_BATT_V=1.35
+export PUMP_URGENT_BATT_V=1.30
+
+export OPENAPS_ENABLE_ALERTS=false
+export OPENAPS_WARN=30
+export OPENAPS_URGENT=60
+export OPENAPS_FIELDS="status-symbol status-label iob meal-assist rssi freq"
+export OPENAPS_RETRO_FIELDS="status-symbol status-label iob meal-assist rssi"
+
+export LOOP_ENABLE_ALERTS=false
+export LOOP_WARN=30
+export LOOP_URGENT=60
+
+export SHOW_PLUGINS=careportal
+export SHOW_FORECAST="ar2 openaps"
+
+export LANGUAGE=en
+export SCALE_Y=log
+export EDIT_MODE=on
+
+npm start


### PR DESCRIPTION
- Tested on Raspberry Pi Zero (rpi0): Working with Raspian Jessie Lite (Release date: 2016-09-23)
- Added docs, e.g. Prerequisites, Wishlist
- Run as user pi instead of root and use start-nightscout.sh
- Logging to /var/log/nightscout.log
- edits to ns-local-install.sh, combine apt-get's, temporary use PieterGit for files (can be changed after merging)
- install openaps dependencies

Will start Nightscout in mmol mode
